### PR TITLE
Properly deal with eos and UNK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ preprocessing scripts, are provided in https://github.com/rsennrich/wmt16-script
 | --output_alignment PATH, -a PATH | Output file for alignment weights (default: standard output) |
 | --json_alignment     | Output alignment in json format |
 | --n-best             | Write n-best list (of size k) |
-| --suppress-unk       | Suppress hypotheses containing UNK. |
+| --suppress-unk       | Suppress hypotheses containing `<UNK>`. |
 | --print-word-probabilities, -wp | Print probabilities of each word |
 | --search_graph, -sg  | Output file for search graph rendered as PNG image |
 | --device-list, -dl      | User specified device list for multi-processing decoding. For example: --device-list gpu0 gpu1 gpu2 |

--- a/data/build_dictionary.py
+++ b/data/build_dictionary.py
@@ -26,10 +26,10 @@ def main():
         sorted_words = [words[ii] for ii in sorted_idx[::-1]]
 
         worddict = OrderedDict()
-        worddict['eos'] = 0
-        worddict['UNK'] = 1
         for ii, ww in enumerate(sorted_words):
             worddict[ww] = ii+2
+        worddict['<eos>'] = 0
+        worddict['<UNK>'] = 1
 
         with open('%s.json'%filename, 'wb') as f:
             json.dump(worddict, f, indent=2, ensure_ascii=False)

--- a/nematus/nmt.py
+++ b/nematus/nmt.py
@@ -1150,10 +1150,10 @@ def train(dim_word=512,  # word vector dimensionality
             worddicts_r[ii][vv] = kk
 
     if n_words_src is None:
-        n_words_src = len(worddicts[0])
+        n_words_src = max(worddicts[0]) + 1
         model_options['n_words_src'] = n_words_src
     if n_words is None:
-        n_words = len(worddicts[-1])
+        n_words = max(worddicts[-1]) + 1
         model_options['n_words'] = n_words
 
     if tie_encoder_decoder_embeddings:

--- a/nematus/translate.py
+++ b/nematus/translate.py
@@ -169,7 +169,7 @@ class Translator(object):
             for kk, vv in word_dict.iteritems():
                 word_idict[vv] = kk
             word_idict[0] = '<eos>'
-            word_idict[1] = 'UNK'
+            word_idict[1] = '<UNK>'
             word_dicts.append(word_dict)
             word_idicts.append(word_idict)
 
@@ -182,7 +182,7 @@ class Translator(object):
         for kk, vv in word_dict_trg.iteritems():
             word_idict_trg[vv] = kk
         word_idict_trg[0] = '<eos>'
-        word_idict_trg[1] = 'UNK'
+        word_idict_trg[1] = '<UNK>'
 
         self._word_idict_trg = word_idict_trg
 

--- a/nematus/util.py
+++ b/nematus/util.py
@@ -40,5 +40,5 @@ def seqs2words(seq, inverse_target_dictionary, join=True):
         if w in inverse_target_dictionary:
             words.append(inverse_target_dictionary[w])
         else:
-            words.append('UNK')
+            words.append('<UNK>')
     return ' '.join(words) if join else words

--- a/utils/copy_unknown_words.py
+++ b/utils/copy_unknown_words.py
@@ -4,9 +4,9 @@ This script is to replace the unknown words in target sentences with their align
 Args: 
 	- input: an alignment file produced by translating with the option '--output_alignment'
 	- output: output text file
-	- unknown word token (optional): a string, default="UNK"
+	- unknown word token (optional): a string, default="<UNK>"
 To use:
-	python copy_unknown_words.py -i translation.txt -o updated_translation.txt -u 'UNK'
+	python copy_unknown_words.py -i translation.txt -o updated_translation.txt -u '<UNK>'
 '''
 
 import json
@@ -16,7 +16,7 @@ import sys
 
 ''' 
 Example input file:
-0 ||| das ist ein Test . ||| 0 ||| this is a UNK . ||| 6 6
+0 ||| das ist ein Test . ||| 0 ||| this is a <UNK> . ||| 6 6
 0.723781 0.0561881 0.0652739 0.0888658 0.0159646 0.0499262
 0.0250772 0.728351 0.105699 0.0764411 0.0245384 0.0398933
 0.0257915 0.0667947 0.543118 0.177978 0.020311 0.166007
@@ -52,8 +52,8 @@ if __name__ == "__main__":
         parser.add_argument('--output', '-o', type=argparse.FileType('w'),
                                                 default=sys.stdout, metavar='PATH',
                                                 help="Output file (default: standard output)")
-        parser.add_argument('--unknown', '-u', type=str, nargs = '?', default="UNK",
-                                                help='Unknown token to be replaced (default: "UNK")')
+        parser.add_argument('--unknown', '-u', type=str, nargs = '?', default="<UNK>",
+                                                help='Unknown token to be replaced (default: "<UNK>")')
 
         args = parser.parse_args()
 


### PR DESCRIPTION
Reverts commit a6eeda7ed6037285627ca6e468a7ef8ab467034f (which reverted 09eb3594fb395d43dd3f6c2a4dec85af683cbb30) and adds angular parentheses around eos and unk.
Nematus now actually uses unk, and if it is not set to 1 it crashes.