### PR TITLE
Added Check for a key if it is present in th2tf mapping

### DIFF
--- a/nematus/theano_tf_convert.py
+++ b/nematus/theano_tf_convert.py
@@ -149,14 +149,15 @@ def theano_to_tensorflow_model(in_path, out_path):
         seen = set()
         assign_ops = []
         for key in saved_model.keys():
-            tf_name = th2tf[key]
-            if tf_name is not None:
-                assert tf_name not in seen
-                seen.add(tf_name)
-                tf_var = tf.get_default_graph().get_tensor_by_name(tf_name)
-                if (sess.run(tf.shape(tf_var)) != saved_model[key].shape).any():
-                    print "mismatch for", tf_name, key, saved_model[key].shape, sess.run(tf.shape(tf_var))
-                assign_ops.append(tf.assign(tf_var, saved_model[key]))
+            if key in th2tf:
+                tf_name = th2tf[key]
+                if tf_name is not None:
+                    assert tf_name not in seen
+                    seen.add(tf_name)
+                    tf_var = tf.get_default_graph().get_tensor_by_name(tf_name)
+                    if (sess.run(tf.shape(tf_var)) != saved_model[key].shape).any():
+                        print "mismatch for", tf_name, key, saved_model[key].shape, sess.run(tf.shape(tf_var))
+                    assign_ops.append(tf.assign(tf_var, saved_model[key]))
             else:
                 print "Not saving", key, "because no TF equivalent"
         sess.run(assign_ops)


### PR DESCRIPTION
I tried converting wmt17 model to tensorflow. I got following error:
```
Traceback (most recent call last):
  File "theano_tf_convert.py", line 215, in <module>
    theano_to_tensorflow_model(opts.inn, opts.out)
  File "theano_tf_convert.py", line 152, in theano_to_tensorflow_model
    tf_name = th2tf[key]
KeyError: 'adam_encoder_r_Ux_drt_2_lnb_mean'
```
Looks like the theano model was not frozen, because the optimizers tensor was still present.
Also `adam` is not required for evaluation(in this case translation). So I am checking if anyother key
other than the keys in `th2tf` mapping is not saved in model. After doing this the code returns following and model is saved in tensorflow:

```
Not saving adam_encoder_r_Ux_drt_2_lnb_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_lnb_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_5_lns_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_6_mean because no TF equivalent
Not saving adam_decoder_U_att_variance because no TF equivalent
Not saving adam_encoder_r_W_variance because no TF equivalent
Not saving adam_encoder_U_drt_3_lns_mean because no TF equivalent
Not saving adam_ff_state_ln_b_mean because no TF equivalent
Not saving adam_decoder_Wc_att_lnb_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_4_lns_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_4_lns_mean because no TF equivalent
Not saving adam_Wemb_variance because no TF equivalent
Not saving adam_decoder_Ux_mean because no TF equivalent
Not saving adam_encoder_U_drt_2_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_5_lns_variance because no TF equivalent
Not saving adam_decoder_W_comb_att_lnb_mean because no TF equivalent
Not saving adam_decoder_U_nl_lnb_mean because no TF equivalent
Not saving adam_encoder_U_lns_mean because no TF equivalent
Not saving adam_ff_logit_ctx_W_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_6_lnb_variance because no TF equivalent
Not saving adam_decoder_W_comb_att_lnb_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_1_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_4_lnb_variance because no TF equivalent
Not saving adam_ff_state_b_mean because no TF equivalent
Not saving adam_decoder_W_comb_att_lns_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_2_lns_mean because no TF equivalent
Not saving adam_decoder_bx_variance because no TF equivalent
Not saving adam_decoder_bx_nl_drt_3_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_3_mean because no TF equivalent
Not saving adam_encoder_r_U_drt_3_mean because no TF equivalent
Not saving adam_ff_logit_lstm_b_variance because no TF equivalent
Not saving adam_encoder_b_drt_2_variance because no TF equivalent
Not saving adam_decoder_c_tt_mean because no TF equivalent
Not saving adam_decoder_U_mean because no TF equivalent
Not saving adam_encoder_r_Ux_lns_mean because no TF equivalent
Not saving adam_encoder_r_Ux_drt_3_lns_mean because no TF equivalent
Not saving adam_decoder_bx_nl_drt_5_mean because no TF equivalent
Not saving adam_decoder_b_nl_drt_1_variance because no TF equivalent
Not saving adam_ff_logit_lstm_W_variance because no TF equivalent
Not saving adam_decoder_Wcx_lnb_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_2_lns_mean because no TF equivalent
Not saving adam_encoder_r_U_drt_3_lnb_variance because no TF equivalent
Not saving adam_encoder_r_U_mean because no TF equivalent
Not saving adam_encoder_r_U_drt_2_mean because no TF equivalent
Not saving adam_encoder_Ux_drt_2_lns_mean because no TF equivalent
Not saving adam_encoder_Ux_drt_3_mean because no TF equivalent
Not saving adam_decoder_Ux_lnb_mean because no TF equivalent
Not saving adam_encoder_r_U_drt_2_lns_mean because no TF equivalent
Not saving adam_decoder_b_nl_drt_4_variance because no TF equivalent
Not saving adam_decoder_bx_nl_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_5_lns_variance because no TF equivalent
Not saving adam_encoder_r_U_drt_2_lnb_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_6_lnb_mean because no TF equivalent
Not saving adam_ff_logit_prev_b_variance because no TF equivalent
Not saving adam_decoder_W_comb_att_mean because no TF equivalent
Not saving adam_encoder_r_U_drt_1_mean because no TF equivalent
Not saving adam_encoder_r_U_drt_3_lns_variance because no TF equivalent
Not saving adam_decoder_U_lnb_mean because no TF equivalent
Not saving adam_decoder_b_nl_drt_5_mean because no TF equivalent
Not saving adam_encoder_bx_variance because no TF equivalent
Not saving adam_encoder_W_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_5_lnb_mean because no TF equivalent
Not saving adam_decoder_Wc_att_lns_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_4_mean because no TF equivalent
Not saving adam_decoder_Wx_mean because no TF equivalent
Not saving adam_encoder_r_Wx_variance because no TF equivalent
Not saving adam_encoder_r_U_lnb_mean because no TF equivalent
Not saving adam_decoder_Wc_att_lnb_mean because no TF equivalent
Not saving adam_encoder_Ux_mean because no TF equivalent
Not saving adam_encoder_U_lns_variance because no TF equivalent
Not saving adam_decoder_U_nl_lnb_variance because no TF equivalent
Not saving adam_encoder_Wx_mean because no TF equivalent
Not saving adam_encoder_r_bx_variance because no TF equivalent
Not saving adam_encoder_r_Ux_lnb_mean because no TF equivalent
Not saving adam_decoder_Wc_lnb_mean because no TF equivalent
Not saving adam_decoder_W_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_4_lnb_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_3_lns_variance because no TF equivalent
Not saving adam_encoder_r_Ux_drt_1_variance because no TF equivalent
Not saving adam_decoder_Wx_lns_mean because no TF equivalent
Not saving adam_decoder_bx_nl_drt_6_variance because no TF equivalent
Not saving adam_Wemb_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_1_mean because no TF equivalent
Not saving adam_encoder_Ux_drt_2_lnb_variance because no TF equivalent
Not saving adam_encoder_r_Ux_drt_3_variance because no TF equivalent
Not saving adam_encoder_U_drt_1_lnb_variance because no TF equivalent
Not saving adam_decoder_bx_nl_drt_2_variance because no TF equivalent
Not saving adam_decoder_Wcx_lnb_variance because no TF equivalent
Not saving adam_encoder_r_Wx_lns_variance because no TF equivalent
Not saving adam_encoder_b_drt_3_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_lns_mean because no TF equivalent
Not saving adam_encoder_r_Ux_drt_3_lns_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_1_lns_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_6_mean because no TF equivalent
Not saving adam_encoder_b_drt_3_mean because no TF equivalent
Not saving adam_encoder_b_drt_1_variance because no TF equivalent
Not saving adam_ff_logit_lstm_b_mean because no TF equivalent
Not saving adam_decoder_U_nl_variance because no TF equivalent
Not saving adam_encoder_Ux_drt_2_mean because no TF equivalent
Not saving adam_encoder_r_b_drt_1_variance because no TF equivalent
Not saving adam_decoder_U_lns_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_2_lns_variance because no TF equivalent
Not saving adam_decoder_b_nl_drt_2_mean because no TF equivalent
Not saving adam_ff_logit_prev_b_mean because no TF equivalent
Not saving adam_encoder_r_Wx_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_6_lnb_mean because no TF equivalent
Not saving adam_encoder_U_drt_1_variance because no TF equivalent
Not saving adam_decoder_b_att_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_lnb_mean because no TF equivalent
Not saving adam_decoder_b_nl_variance because no TF equivalent
Not saving adam_encoder_r_b_drt_3_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_5_variance because no TF equivalent
Not saving adam_decoder_bx_nl_drt_3_variance because no TF equivalent
Not saving adam_decoder_bx_nl_drt_5_variance because no TF equivalent
Not saving adam_encoder_Ux_drt_3_lnb_variance because no TF equivalent
Not saving adam_ff_logit_b_mean because no TF equivalent
Not saving adam_encoder_b_drt_2_mean because no TF equivalent
Not saving adam_encoder_r_U_drt_1_lnb_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_6_lns_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_4_variance because no TF equivalent
Not saving adam_ff_logit_prev_W_mean because no TF equivalent
Not saving adam_ff_logit_lstm_ln_s_variance because no TF equivalent
Not saving adam_decoder_U_nl_lns_variance because no TF equivalent
Not saving adam_encoder_U_lnb_variance because no TF equivalent
Not saving adam_encoder_Ux_drt_3_lns_variance because no TF equivalent
Not saving adam_encoder_r_Wx_lnb_mean because no TF equivalent
Not saving adam_encoder_r_U_drt_1_lns_variance because no TF equivalent
Not saving adam_encoder_U_drt_1_lns_mean because no TF equivalent
Not saving adam_encoder_r_bx_drt_3_variance because no TF equivalent
Not saving adam_encoder_r_W_lnb_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_3_lnb_variance because no TF equivalent
Not saving adam_Wemb_dec_variance because no TF equivalent
Not saving adam_encoder_U_drt_1_lns_variance because no TF equivalent
Not saving adam_encoder_r_U_drt_2_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_6_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_4_variance because no TF equivalent
Not saving adam_encoder_r_W_mean because no TF equivalent
Not saving adam_ff_logit_ctx_ln_s_mean because no TF equivalent
Not saving adam_encoder_r_Ux_drt_3_lnb_variance because no TF equivalent
Not saving adam_decoder_bx_nl_drt_4_variance because no TF equivalent
Not saving adam_encoder_r_W_lns_variance because no TF equivalent
Not saving adam_decoder_Wc_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_2_variance because no TF equivalent
Not saving adam_decoder_W_comb_att_variance because no TF equivalent
Not saving adam_decoder_W_lns_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_4_lnb_mean because no TF equivalent
Not saving adam_encoder_Ux_drt_3_lns_mean because no TF equivalent
Not saving adam_encoder_r_b_drt_1_mean because no TF equivalent
Not saving adam_encoder_W_lns_variance because no TF equivalent
Not saving adam_ff_state_ln_s_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_6_variance because no TF equivalent
Not saving adam_encoder_Ux_lnb_variance because no TF equivalent
Not saving adam_encoder_r_Ux_drt_2_variance because no TF equivalent
Not saving adam_decoder_b_nl_drt_6_mean because no TF equivalent
Not saving adam_decoder_b_att_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_1_lnb_mean because no TF equivalent
Not saving adam_encoder_r_U_drt_1_lnb_variance because no TF equivalent
Not saving adam_encoder_U_drt_3_lnb_mean because no TF equivalent
Not saving adam_encoder_U_drt_1_mean because no TF equivalent
Not saving adam_decoder_Wx_lnb_mean because no TF equivalent
Not saving adam_encoder_r_U_drt_3_lns_mean because no TF equivalent
Not saving adam_decoder_Wcx_mean because no TF equivalent
Not saving adam_ff_logit_lstm_W_mean because no TF equivalent
Not saving adam_encoder_r_U_drt_2_lns_variance because no TF equivalent
Not saving adam_encoder_U_lnb_mean because no TF equivalent
Not saving adam_encoder_r_W_lns_mean because no TF equivalent
Not saving adam_decoder_U_att_mean because no TF equivalent
Not saving adam_encoder_bx_drt_2_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_variance because no TF equivalent
Not saving adam_decoder_Wcx_lns_mean because no TF equivalent
Not saving adam_encoder_Ux_drt_3_lnb_mean because no TF equivalent
Not saving adam_encoder_r_Ux_variance because no TF equivalent
Not saving adam_encoder_r_U_lns_mean because no TF equivalent
Not saving adam_decoder_U_nl_lns_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_6_lnb_variance because no TF equivalent
Not saving adam_encoder_r_U_lns_variance because no TF equivalent
Not saving adam_decoder_b_nl_drt_3_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_5_variance because no TF equivalent
Not saving adam_decoder_Ux_lns_mean because no TF equivalent
Not saving adam_decoder_Wc_att_variance because no TF equivalent
Not saving adam_encoder_Ux_lns_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_2_lnb_mean because no TF equivalent
Not saving adam_ff_logit_ctx_ln_b_variance because no TF equivalent
Not saving adam_encoder_r_U_drt_2_lnb_variance because no TF equivalent
Not saving adam_encoder_U_drt_1_lnb_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_2_variance because no TF equivalent
Not saving adam_encoder_U_mean because no TF equivalent
Not saving adam_decoder_Wcx_lns_variance because no TF equivalent
Not saving adam_decoder_W_lnb_variance because no TF equivalent
Not saving adam_encoder_r_Wx_lns_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_2_lnb_variance because no TF equivalent
Not saving adam_decoder_Wx_variance because no TF equivalent
Not saving adam_encoder_r_Ux_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_3_variance because no TF equivalent
Not saving adam_encoder_r_Ux_drt_3_lnb_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_1_variance because no TF equivalent
Not saving adam_encoder_Ux_variance because no TF equivalent
Not saving adam_ff_logit_prev_ln_b_variance because no TF equivalent
Not saving adam_encoder_r_Ux_drt_2_lns_mean because no TF equivalent
Not saving adam_decoder_Wc_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_1_lnb_variance because no TF equivalent
Not saving adam_encoder_W_lnb_variance because no TF equivalent
Not saving adam_encoder_Wx_lnb_variance because no TF equivalent
Not saving adam_encoder_r_U_drt_3_lnb_mean because no TF equivalent
Not saving adam_ff_state_ln_s_mean because no TF equivalent
Not saving adam_Wemb_dec_mean because no TF equivalent
Not saving adam_encoder_r_Ux_drt_3_mean because no TF equivalent
Not saving adam_encoder_r_b_drt_2_variance because no TF equivalent
Not saving adam_encoder_r_W_lnb_mean because no TF equivalent
Not saving adam_encoder_b_drt_1_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_3_lns_mean because no TF equivalent
Not saving adam_ff_logit_prev_W_variance because no TF equivalent
Not saving adam_encoder_Ux_drt_1_lnb_mean because no TF equivalent
Not saving adam_decoder_U_lns_mean because no TF equivalent
Not saving adam_encoder_U_drt_2_variance because no TF equivalent
Not saving adam_decoder_bx_nl_drt_4_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_4_lnb_variance because no TF equivalent
Not saving adam_encoder_r_Wx_lnb_variance because no TF equivalent
Not saving adam_decoder_Wx_lnb_variance because no TF equivalent
Not saving adam_decoder_Wcx_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_1_variance because no TF equivalent
Not saving adam_ff_logit_lstm_ln_b_variance because no TF equivalent
Not saving adam_decoder_bx_nl_mean because no TF equivalent
Not saving adam_decoder_Wc_att_lns_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_3_lnb_mean because no TF equivalent
Not saving adam_encoder_r_bx_drt_1_mean because no TF equivalent
Not saving adam_decoder_Wc_lnb_variance because no TF equivalent
Not saving adam_encoder_r_Ux_drt_1_lnb_variance because no TF equivalent
Not saving adam_decoder_bx_nl_drt_2_mean because no TF equivalent
Not saving adam_encoder_U_drt_2_lns_variance because no TF equivalent
Not saving adam_encoder_W_lnb_mean because no TF equivalent
Not saving adam_decoder_U_lnb_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_1_lnb_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_3_variance because no TF equivalent
Not saving adam_ff_state_W_mean because no TF equivalent
Not saving adam_encoder_U_drt_3_variance because no TF equivalent
Not saving adam_encoder_U_drt_2_lnb_variance because no TF equivalent
Not saving adam_encoder_Wx_lns_mean because no TF equivalent
Not saving adam_decoder_W_lns_variance because no TF equivalent
Not saving adam_encoder_bx_drt_3_variance because no TF equivalent
Not saving adam_encoder_r_Ux_drt_1_lnb_mean because no TF equivalent
Not saving adam_ff_logit_prev_ln_s_mean because no TF equivalent
Not saving adam_encoder_Ux_drt_1_lnb_variance because no TF equivalent
Not saving adam_ff_state_ln_b_variance because no TF equivalent
Not saving adam_ff_logit_prev_ln_s_variance because no TF equivalent
Not saving adam_encoder_Wx_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_3_lns_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_2_mean because no TF equivalent
Not saving adam_encoder_Ux_drt_1_lns_variance because no TF equivalent
Not saving adam_encoder_r_b_drt_3_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_6_lns_mean because no TF equivalent
Not saving adam_encoder_Ux_drt_2_lnb_mean because no TF equivalent
Not saving adam_decoder_Wx_lns_variance because no TF equivalent
Not saving adam_decoder_U_variance because no TF equivalent
Not saving adam_encoder_r_U_drt_1_lns_mean because no TF equivalent
Not saving adam_encoder_U_drt_2_lnb_mean because no TF equivalent
Not saving adam_decoder_Wc_lns_variance because no TF equivalent
Not saving adam_ff_logit_ctx_W_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_3_lnb_variance because no TF equivalent
Not saving adam_encoder_Ux_drt_1_mean because no TF equivalent
Not saving adam_decoder_b_variance because no TF equivalent
Not saving adam_encoder_bx_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_5_mean because no TF equivalent
Not saving adam_encoder_bx_drt_3_mean because no TF equivalent
Not saving adam_ff_logit_lstm_ln_b_mean because no TF equivalent
Not saving adam_encoder_Ux_drt_1_lns_mean because no TF equivalent
Not saving adam_encoder_r_bx_mean because no TF equivalent
Not saving adam_decoder_bx_mean because no TF equivalent
Not saving adam_decoder_Wc_lns_mean because no TF equivalent
Not saving adam_encoder_bx_drt_2_variance because no TF equivalent
Not saving adam_encoder_Ux_lnb_mean because no TF equivalent
Not saving adam_encoder_r_b_drt_2_mean because no TF equivalent
Not saving adam_decoder_b_nl_drt_4_mean because no TF equivalent
Not saving adam_encoder_r_Ux_lnb_variance because no TF equivalent
Not saving adam_encoder_Ux_drt_1_variance because no TF equivalent
Not saving adam_decoder_W_lnb_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_5_lns_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_4_lns_variance because no TF equivalent
Not saving adam_encoder_r_bx_drt_2_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_5_lnb_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_5_lnb_variance because no TF equivalent
Not saving adam_encoder_r_U_lnb_variance because no TF equivalent
Not saving adam_decoder_Wc_att_mean because no TF equivalent
Not saving adam_encoder_r_b_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_3_lnb_mean because no TF equivalent
Not saving adam_encoder_U_drt_3_mean because no TF equivalent
Not saving adam_encoder_W_lns_mean because no TF equivalent
Not saving adam_ff_logit_ctx_ln_b_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_1_lns_mean because no TF equivalent
Not saving adam_encoder_Ux_lns_mean because no TF equivalent
Not saving adam_decoder_Ux_variance because no TF equivalent
Not saving adam_encoder_Ux_drt_2_lns_variance because no TF equivalent
Not saving adam_encoder_r_Ux_drt_2_lnb_variance because no TF equivalent
Not saving adam_decoder_W_comb_att_lns_variance because no TF equivalent
Not saving adam_decoder_Ux_lns_variance because no TF equivalent
Not saving adam_ff_state_W_variance because no TF equivalent
Not saving adam_encoder_U_drt_2_lns_mean because no TF equivalent
Not saving adam_encoder_r_Ux_drt_2_mean because no TF equivalent
Not saving adam_encoder_U_drt_3_lns_variance because no TF equivalent
Not saving adam_encoder_r_Ux_lns_variance because no TF equivalent
Not saving adam_encoder_r_Ux_drt_1_lns_variance because no TF equivalent
Not saving adam_encoder_Wx_lnb_mean because no TF equivalent
Not saving adam_decoder_b_nl_drt_1_mean because no TF equivalent
Not saving adam_encoder_r_Ux_drt_2_lns_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_4_lns_mean because no TF equivalent
Not saving adam_decoder_b_nl_drt_6_variance because no TF equivalent
Not saving adam_encoder_r_bx_drt_3_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_4_mean because no TF equivalent
Not saving adam_ff_state_b_variance because no TF equivalent
Not saving adam_decoder_bx_nl_drt_1_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_3_lns_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_2_mean because no TF equivalent
Not saving adam_decoder_bx_nl_drt_1_variance because no TF equivalent
Not saving adam_encoder_U_drt_3_lnb_variance because no TF equivalent
Not saving adam_decoder_b_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_5_mean because no TF equivalent
Not saving adam_encoder_b_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_6_lns_mean because no TF equivalent
Not saving adam_decoder_b_nl_mean because no TF equivalent
Not saving adam_encoder_r_Ux_drt_1_lns_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_2_lns_variance because no TF equivalent
Not saving adam_encoder_r_bx_drt_1_variance because no TF equivalent
Not saving adam_decoder_U_nl_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_5_lnb_mean because no TF equivalent
Not saving adam_ff_logit_ctx_ln_s_variance because no TF equivalent
Not saving adam_ff_logit_ctx_b_variance because no TF equivalent
Not saving adam_encoder_bx_drt_1_mean because no TF equivalent
Not saving adam_encoder_bx_drt_1_variance because no TF equivalent
Not saving adam_encoder_W_mean because no TF equivalent
Not saving adam_decoder_Ux_lnb_variance because no TF equivalent
Not saving adam_encoder_Ux_drt_3_variance because no TF equivalent
Not saving adam_encoder_b_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_1_lnb_mean because no TF equivalent
Not saving adam_encoder_Wx_lns_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_lns_variance because no TF equivalent
Not saving adam_ff_logit_ctx_b_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_2_lnb_mean because no TF equivalent
Not saving adam_encoder_U_variance because no TF equivalent
Not saving adam_decoder_U_nl_drt_6_lns_variance because no TF equivalent
Not saving adam_encoder_r_bx_drt_2_variance because no TF equivalent
Not saving adam_encoder_r_b_variance because no TF equivalent
Not saving adam_ff_logit_b_variance because no TF equivalent
Not saving adam_decoder_W_variance because no TF equivalent
Not saving adam_ff_logit_lstm_ln_s_mean because no TF equivalent
Not saving adam_decoder_U_nl_drt_2_lnb_variance because no TF equivalent
Not saving adam_decoder_b_nl_drt_3_variance because no TF equivalent
Not saving adam_encoder_r_U_drt_3_variance because no TF equivalent
Not saving adam_encoder_Ux_drt_2_variance because no TF equivalent
Not saving adam_t_prev because no TF equivalent
Not saving adam_decoder_b_nl_drt_2_variance because no TF equivalent
Not saving adam_decoder_bx_nl_drt_6_mean because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_3_mean because no TF equivalent
Not saving adam_encoder_r_U_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_1_lns_variance because no TF equivalent
Not saving adam_encoder_r_U_drt_1_variance because no TF equivalent
Not saving adam_decoder_Ux_nl_drt_1_lns_mean because no TF equivalent
Not saving adam_encoder_r_Ux_drt_1_mean because no TF equivalent
Not saving adam_decoder_c_tt_variance because no TF equivalent
Not saving adam_ff_logit_prev_ln_b_mean because no TF equivalent
Not saving adam_decoder_b_nl_drt_5_variance because no TF equivalent
The following TF variables were not assigned (excluding Adam vars):
You should see only 'beta1_power', 'beta2_power' and 'time' variable listed
time:0
beta1_power:0
beta2_power:0

```
Let me know if this is expected behaviour. 
Best Regards,
Himanshu