### PR TITLE
Bugfix in transformer.py

### DIFF
--- a/nematus/transformer.py
+++ b/nematus/transformer.py
@@ -345,9 +345,6 @@ class TransformerDecoder(object):
 
         def _decode_all(target_embeddings):
             """ Decodes the encoder-generated representations into target-side logits in parallel. """
-            # Apply input dropout
-            dec_input = \
-                tf.layers.dropout(target_embeddings, rate=self.config.transformer_dropout_embeddings, training=self.training)
             # Propagate inputs through the encoder stack
             dec_output = dec_input
             for layer_id in range(1, self.config.transformer_dec_depth + 1):

--- a/nematus/transformer.py
+++ b/nematus/transformer.py
@@ -346,7 +346,7 @@ class TransformerDecoder(object):
         def _decode_all(target_embeddings):
             """ Decodes the encoder-generated representations into target-side logits in parallel. """
             # Propagate inputs through the encoder stack
-            dec_output = dec_input
+            dec_output = target_embeddings
             for layer_id in range(1, self.config.transformer_dec_depth + 1):
                 dec_output, _ = self.decoder_stack[layer_id]['self_attn'].forward(dec_output, None, self_attn_mask)
                 dec_output, _ = \


### PR DESCRIPTION
It seems that the dropout is applied twice to the embedding of the Transformer decoder.