### PR TITLE
bug: non-deterministic decoding with exponential smoothing

### DIFF
--- a/nematus/exponential_smoothing.py
+++ b/nematus/exponential_smoothing.py
@@ -48,7 +48,8 @@ class ExponentialSmoothing(object):
                 name = v.name[:-2] + "_smooth"
                 s = tf.get_variable(name=name,
                                     initializer=tf.zeros_like(v),
-                                    trainable=False)
+                                    trainable=False,
+                                    use_resource=True)
                 smooth_vars[v.name] = s
             # Define the ops to update the smoothed variables.
             self._update_ops = []


### PR DESCRIPTION
With tensorflow 1.12 and exponential smoothing enabled, decoding is non-deterministic.

In training, tf.enable_resource_variables() is set which makes the default for use_resource in get_variable() True. 

For translation and scoring, it is not set. Then, the current default for use_resource is False and get_variable() returns a normal Variable. With normal Variables instead of ResourceVariables at test time, the decoding becomes non-deterministic.