### PR TITLE
add support for DropHead (Zhou et al., 2020)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Notable features include:
      - mixture of softmaxes (Yang et al., 2017) https://arxiv.org/abs/1711.03953
      - lexical model (Nguyen and Chiang, 2018) https://www.aclweb.org/anthology/N18-1031
 
+  - support for advanced Transformer architectures:
+     - DropHead: dropout of entire attention heads (Zhou et al., 2020) https://arxiv.org/abs/2004.13342
+
  - training features:
      - multi-GPU support [documentation](doc/multi_gpu_training.md)
      - label smoothing
@@ -169,6 +172,7 @@ An updated version of these scripts that uses the Transformer model can be found
 | --transformer_dropout_residual FLOAT | dropout applied to residual connections (default: 0.1) |
 | --transformer_dropout_relu FLOAT | dropout applied to the internal activation of the feed-forward sub-layers (default: 0.1) |
 | --transformer_dropout_attn FLOAT | dropout applied to attention weights (default: 0.1) |
+| --transformer_drophead FLOAT | dropout of entire attention heads (default: 0.0) |
 
 #### training parameters
 | parameter | description |

--- a/nematus/config.py
+++ b/nematus/config.py
@@ -533,6 +533,13 @@ class ConfigSpecification:
             help='dropout applied to attention weights (default: '
                  '%(default)s)'))
 
+        group.append(ParameterSpecification(
+            name='transformer_drophead', default=0.0,
+            visible_arg_names=['--transformer_drophead'],
+            type=float, metavar='FLOAT',
+            help='dropout of entire attention heads (default: '
+                 '%(default)s)'))
+
         # Add command-line parameters for 'training' group.
 
         group = param_specs['training']

--- a/nematus/transformer_attention_modules.py
+++ b/nematus/transformer_attention_modules.py
@@ -28,6 +28,7 @@ class MultiHeadAttentionLayer(object):
                  num_heads,
                  float_dtype,
                  dropout_attn,
+                 drophead,
                  training,
                  name=None):
 
@@ -40,6 +41,7 @@ class MultiHeadAttentionLayer(object):
         self.num_heads = num_heads
         self.float_dtype = float_dtype
         self.dropout_attn = dropout_attn
+        self.drophead = drophead
         self.training = training
         self.name = name
 
@@ -159,6 +161,11 @@ class MultiHeadAttentionLayer(object):
         # Optionally apply dropout:
         if self.dropout_attn > 0.0:
             attn_weights = tf.compat.v1.layers.dropout(attn_weights, rate=self.dropout_attn, training=self.training)
+        # Optionally apply DropHead:
+        if self.drophead > 0.0:
+            attn_weights = tf.compat.v1.layers.dropout(attn_weights, rate=self.drophead,
+                                                       noise_shape=[tf.shape(input=attn_weights)[0], tf.shape(input=attn_weights)[1], 1, 1],
+                                                       training=self.training)
         # Weigh attention values
         weighted_memories = tf.matmul(attn_weights, values)
         return weighted_memories

--- a/nematus/transformer_blocks.py
+++ b/nematus/transformer_blocks.py
@@ -62,6 +62,7 @@ class AttentionBlock(object):
                                             config.transformer_num_heads,
                                             float_dtype,
                                             dropout_attn=config.transformer_dropout_attn,
+                                            drophead=config.transformer_drophead,
                                             training=training,
                                             name='{:s}_sublayer'.format(attn_name))
 


### PR DESCRIPTION
Ran some experiments with DropHead ([Zhou et al., 2020](https://arxiv.org/pdf/2004.13342.pdf)) vs. standard transformer attention dropout.

The implementation makes use of `noise_shape` in `tf.compat.v1.layers.dropout`.

Here are some results for bilingual mt systems for en-de and de-en on 1 million sentence pairs from the OPUS-100 corpus:

dropout rate 0.1:
en-de:    29.0 (with Dropout)    29.4 (with DropHead)
de-en:    32.3 (with Dropout)    32.4 (with DropHead)

dropout rate 0.2:
en-de:    29.3 (with Dropout)    29.6 (with DropHead)
de-en:    32.3 (with Dropout)    32.9 (with DropHead)